### PR TITLE
Implementation Improvement for nougat.inference

### DIFF
--- a/nougat/model.py
+++ b/nougat/model.py
@@ -574,10 +574,6 @@ class NougatModel(PreTrainedModel):
         if self.device.type == "cuda":  # half is not compatible in cpu implementation.
             image_tensors = image_tensors.to(self.device)
 
-        last_hidden_state = self.encoder(image_tensors)
-        if self.device.type != "cuda":
-            last_hidden_state = last_hidden_state.to(torch.float32)
-
         last_hidden_state = self.encoder(image_tensors).to(torch.bfloat16)
         encoder_outputs = ModelOutput(
             last_hidden_state=last_hidden_state, attentions=None


### PR DESCRIPTION
In the inference process, it appears that [the forward pass of the encoder is executed twice](https://github.com/facebookresearch/nougat/blob/c8c33a6e83da8d8ca56c47ac77cfcfe5fc2ebfe0/nougat/model.py#L577-L580), and the output of the second run consistently overwrites the results of the first run.