### PR TITLE
allow specifying model tag and batch size from environment variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,8 +23,9 @@ from nougat.dataset.rasterize import rasterize_paper
 from tqdm import tqdm
 
 SAVE_DIR = Path("./pdfs")
-BATCHSIZE = os.environ.get("NOUGAT_BATCHSIZE", 6)
-NOUGAT_CHECKPOINT = get_checkpoint()
+BATCHSIZE = int(os.environ.get("NOUGAT_BATCHSIZE", 6))
+MODEL_TAG=os.environ.get("NOUGAT_MODEL_TAG", "0.1.0-small")
+NOUGAT_CHECKPOINT = get_checkpoint(model_tag=MODEL_TAG)
 if NOUGAT_CHECKPOINT is None:
     print(
         "Set environment variable 'NOUGAT_CHECKPOINT' with a path to the model checkpoint!."


### PR DESCRIPTION
A small fix to allow specifying the model tag and the batch size in env variables.
Current code fail when `NOUGAT_BATCHSIZE` is set because python sees it at a string, not an integer.

If nothing is set, the behavior is the same as without these changes