### PR TITLE
Prevent pip from installing old version of lightning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "orjson",
         "opencv-python-headless",
         "datasets[vision]",
-        "lightning>=2.0.0",
+        "lightning>=2.0.0,<2022",
         "nltk",
         "python-Levenshtein",
         "sentencepiece",


### PR DESCRIPTION
This fix makes sure that nougat installs lightning 2.x.x and not lightning 2022.10.25 which is older that 2.x.x

`lightning` used to use `year.mm.dd` versioning scheme before they switched to the standard semantic versioning. Without this fix, `lightning>=2.0.0` matched `2022.10.25` which is __older__ than `2.x.x`. This leads to a deprecation warning or broken installation (depending on the python/pip versions) due to the [bug](https://github.com/Lightning-AI/lightning/issues/18563) in older lightning versions. 
