### PR TITLE
Added mention of minimum Python requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This is the official repository for Nougat, the academic document PDF parser tha
 
 Project page: https://facebookresearch.github.io/nougat/
 
+## Minimum Requirements
+
+- Python 3.10
+
 ## Install
 
 From pip:


### PR DESCRIPTION
`rasterize.py` features union types in type hints which was only introduced as a feature in Python 3.10 (you get a TypeError when running on previous Python versions). Figured it would be cool to explicitly mention this requirement before installation instructions.