### PR TITLE
Fix create_index.read_metadata

### DIFF
--- a/nougat/dataset/create_index.py
+++ b/nougat/dataset/create_index.py
@@ -41,7 +41,7 @@ def read_metadata(data: Dict) -> List[List[Dict]]:
     out = [[] for _ in range(N)]
     # pdffigures2 meta data
     if "pdffigures" in data and data["pdffigures"]:
-        for item in data["pdffigures"]:
+        for item in data["pdffigures"]["figures"]:
             p = item.pop("page", None)
             if p is None or p >= N:
                 continue


### PR DESCRIPTION
The current dataset creation tutorial indicated in the README fails because the structure of the `meta.json` files has changed, as described in https://github.com/facebookresearch/nougat/issues/140

I submit here the fix that worked for me to be merged on the main branch.