### PR TITLE
Add config option to specify float precision type during training

### DIFF
--- a/config/train_nougat.yaml
+++ b/config/train_nougat.yaml
@@ -33,4 +33,5 @@ max_steps: -1
 val_check_interval: null
 check_val_every_n_epoch: 1
 gradient_clip_val: 0.5
+precision: "bf16-mixed"
 verbose: False

--- a/train.py
+++ b/train.py
@@ -190,7 +190,7 @@ def train(config):
         limit_val_batches=config.val_batches,
         gradient_clip_val=config.gradient_clip_val,
         log_every_n_steps=15,
-        precision="bf16-mixed",
+        precision=config.precision,
         num_sanity_val_steps=0,
         logger=logger,
         callbacks=[


### PR DESCRIPTION
Not all CUDA devices support mixed-type precision - myself I got this error when launching `train.py`:

> RuntimeError: Current CUDA Device does not support bfloat16. Please switch dtype to float16.

Therefore I propose this PR to let the user choose which type of precision they want to use during training.
