### PR TITLE
Render PDF pages individually

### DIFF
--- a/nougat/dataset/rasterize.py
+++ b/nougat/dataset/rasterize.py
@@ -43,12 +43,9 @@ def rasterize_paper(
             pdf = pypdfium2.PdfDocument(pdf)
         if pages is None:
             pages = range(len(pdf))
-        renderer = pdf.render(
-            pypdfium2.PdfBitmap.to_pil,
-            page_indices=pages,
-            scale=dpi / 72,
-        )
-        for i, image in zip(pages, renderer):
+
+        for i in pages:
+            image = pdf[i].render(scale=dpi / 72).to_pil()
             if return_pil:
                 page_bytes = io.BytesIO()
                 image.save(page_bytes, "bmp")


### PR DESCRIPTION
Addresses https://github.com/facebookresearch/nougat/issues/110

This removes multi-processing, which may or may not lead to a performance hit when loading documents with many pages. On the one hand, with this modification, nougat now uses a single process for sequential rendering of all PDF pages. On the other, it now avoids copying bitmaps across processes.

The benefit is that this makes it possible to implement nougat in already parallelised workflows (e.g., when reading multiple PDF files, each in a separate process)