### PR TITLE
Resolved error: PDFDocument object has no attribute 'render' 

### DIFF
--- a/nougat/dataset/rasterize.py
+++ b/nougat/dataset/rasterize.py
@@ -43,12 +43,18 @@ def rasterize_paper(
             pdf = pypdfium2.PdfDocument(pdf)
         if pages is None:
             pages = range(len(pdf))
-        renderer = pdf.render(
-            pypdfium2.PdfBitmap.to_pil,
-            page_indices=pages,
-            scale=dpi / 72,
-        )
-        for i, image in zip(pages, renderer):
+        images = []
+        for idx in pages:
+            page = pdf.get_page(idx)
+
+            pil_image = page.render(
+                scale = dpi / 72,
+                rotation = 0,
+            ).to_pil()
+
+            images.append(pil_image)
+            page.close()
+        for i, image in zip(pages, images):
             if return_pil:
                 page_bytes = io.BytesIO()
                 image.save(page_bytes, "bmp")


### PR DESCRIPTION
As **`pypdfium2 `does not render pages at the document level** rather it is done at the **page level**
Hence the below change will fix the issue
From
```python
renderer = pdf.render(
            pypdfium2.PdfBitmap.to_pil,
            page_indices=pages,
            scale=dpi / 72,
        )
for i, image in zip(pages, renderer):
```
to
```python
images = []
for idx in pages:
     page = pdf.get_page(idx)

      pil_image = page.render(
          scale = dpi / 72,
          rotation = 0,
       ).to_pil()

      images.append(pil_image)
      page.close()
for i, image in zip(pages, images):
```
